### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 # =============================================================================
 # The CoalForge team manages all CI/CD workflows and GitHub Actions.
 # Changes to automation should be reviewed by the platform team.
-/.github/workflows/     @Coalfire-CF/CoalForge
+/.github/workflows/     @Coalfire-CF/cs-coalforge
 
 # =============================================================================
 # LICENSE & LEGAL

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,27 @@
-# These owners will be the default owners for everything in the repo. Unless a later match takes precedence.
+# CODEOWNERS - Defines who must review and approve PRs for specific files/paths
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# IMPORTANT: Rules are evaluated top-to-bottom, and the LAST matching pattern takes precedence.
+# This means more specific rules should be placed AFTER general rules.
 
-* @mscribellito @jemadd04
+# =============================================================================
+# DEFAULT OWNERS
+# =============================================================================
+# The PAK (Product Area Knowledge) team and Cloud Codeowners own all files by default.
+# Any PR that doesn't match a more specific rule below will require their review.
+*                       @Coalfire-CF/gcp-pak-owners @Coalfire-CF/CS-GCP-Codeowners
+
+# =============================================================================
+# GITHUB WORKFLOWS & ACTIONS
+# =============================================================================
+# The CoalForge team manages all CI/CD workflows and GitHub Actions.
+# Changes to automation should be reviewed by the platform team.
+/.github/workflows/     @Coalfire-CF/CoalForge
+
+# =============================================================================
+# LICENSE & LEGAL
+# =============================================================================
+# License changes require department head approval due to legal implications.
+# This ensures proper oversight for any licensing modifications.
+LICENSE                 @douglas-f
+


### PR DESCRIPTION
Updates CODEOWNERS file to define code review requirements:

- Default owners: @Coalfire-CF/gcp-pak-owners @Coalfire-CF/CS-GCP-Codeowners
- GitHub workflows: @Coalfire-CF/CoalForge
- LICENSE: @douglas-f

This ensures proper review coverage for all changes to this repository.